### PR TITLE
Fix ignored json config setting

### DIFF
--- a/PipelineBuilder.php
+++ b/PipelineBuilder.php
@@ -109,9 +109,22 @@ class PipelineBuilder
     */
     public function build()
     {
-        $this->flowElements = array_merge($this->flowElements, 
-                                        $this->getJavaScriptElements(), 
-                                        $this->getSetHeaderElements());
+        $flowElements = array_merge(
+            $this->flowElements,
+            $this->getJavaScriptElements(),
+            $this->getSetHeaderElements()
+        );
+
+        foreach ($flowElements as $i => $element) {
+            if (
+                $element instanceof JavascriptBuilderElement &&
+                empty($element->settings['_endpoint'])
+            ) {
+                unset($flowElements[$i]);
+            }
+        }
+
+        $this->flowElements = $flowElements;
 
         return new Pipeline($this->flowElements, $this->settings);
     }


### PR DESCRIPTION
It turns out that the `endpoint` setting wasn't ignored, rather there were two instances of `JavascriptBuilderElement`s passed to `Pipeline`'s constructor. 
The first was constructed with the settings from the json config file within a call to `PipelineBuilder::buildFromConfig()`, while the other came from `PipelineBuilder::getJavaScriptElements()` via a call to `array_merge()` in `PipelineBuilder::build()`. 
Because `PipelineBuilder`'s constructor did not receive any settings in `gettingStartedWeb.php`, it's `javascriptBuilderSettings` property is not declared, so `getJavaScriptElements()` returns an extra `JavascriptBuilderElement` without the settings from the json config file.
The list of elements passed to Pipeline's constructor is then: 
 1. `DeviceDetectionOnPremise` (from json config)
 2. `JsonBundlerElement` (from json config)
 3. `JavascriptBuilderElement` (from json config)
 4. `SequenceElement` (from `getJavaScriptElements()`)
 5. `JsonBundlerElement` (from `getJavaScriptElements()`)
 6. `JavascriptBuilderElement` (from `getJavaScriptElements()`)
 7. `SetHeaderElement` (from `getSetHeaderElements()`)

in that order. 
This behaviour isn't in accordance to the [spec](https://github.com/51Degrees/specifications/blob/main/pipeline-specification/features/web-integration.md#pipeline-configuration).

This PR provides element deduplication and ensures their order is correct, at least for the `gettingStartedWeb.php` example.